### PR TITLE
feat: add middlewares custom container props

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "0.3.0"
 description: Helm chart for Homing Pigeon
 name: homing-pigeon
 icon: https://raw.githubusercontent.com/softonic/homing-pigeon/master/images/logo.png
-version: 0.10.2
+version: 0.10.3
 maintainers:
 - name: Jose Manuel Cardona
   email: josemanuel.cardona@softonic.com

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Helm chart for https://github.com/softonic/homing-pigeon
 | `image.repository`                        | Image repository                                                                          | `softonic/homing-pigeon` |
 | `image.tag`                               | Tag used for the image                                                                    | `0.1.0`                  |
 | `image.pullPolicy`                        | Image pull policy                                                                         | `IfNotPresent`           |
+| `imagePullSecrets`                        | Image pull secrets array                                                                  | `[]`                     |
 | `resources`                               | Resources policy                                                                          | `{}`                     |
 | `updateStrategy`                          | Update strategy for statefulset                                                           | `null`                   |
 | `nodeSelector`                            | Node Selector for homing pigeon deployment                                                | `{}`                     |
@@ -54,12 +55,20 @@ Helm chart for https://github.com/softonic/homing-pigeon
 | `requestMiddlewares[*].pullPolicy`        | middleware image pull policy                                                              | `IfNotPresent`           |
 | `requestMiddlewares[*].inSocket`          | specifies the URL that exposes the middleware*                                            | `null`                   |
 | `requestMiddlewares[*].outSocket`         | specifies the URL that will be used to connect to the next middleware in the queue*       | `null`                   |
+| `requestMiddlewares[*].env`               | container env vars*                                                                       | `null`                   |
+| `requestMiddlewares[*].resources`         | container resources*                                                                      | `null`                   |
+| `requestMiddlewares[*].command`           | container command*                                                                        | `null`                   |
+| `requestMiddlewares[*].args`              | container args*                                                                           | `null`                   |
 | `responseMiddlewares[*].name`             | middleware name                                                                           | `null`                   |
 | `responseMiddlewares[*].repository`       | middleware image repository                                                               | `null`                   |
 | `responseMiddlewares[*].tag`              | middleware image tag                                                                      | `null`                   |
 | `responseMiddlewares[*].pullPolicy`       | middleware image pull policy                                                              | `IfNotPresent`           |
 | `responseMiddlewares[*].inSocket`         | specifies the URL that exposes the middleware*                                            | `null`                   |
 | `responseMiddlewares[*].outSocket`        | specifies the URL that will be used to connect to the next middleware in the queue*       | `null`                   |
+| `responseMiddlewares[*].env`              | container env vars*                                                                       | `null`                   |
+| `responseMiddlewares[*].resources`        | container resources*                                                                      | `null`                   |
+| `responseMiddlewares[*].command`          | container command*                                                                        | `null`                   |
+| `responseMiddlewares[*].args`             | container args*                                                                           | `null`                   |
 
 <sub>* These options are not compatible when the middleware is configured with an image.</sub>
 
@@ -71,7 +80,7 @@ QueueName templating available variables:
 
 ### Middlewares
 
-You can define middlewares using the `requestMiddlewares` and `responseMiddlewares` keys. 
+You can define middlewares using the `requestMiddlewares` and `responseMiddlewares` keys.
 
 Middlewares will be concatenated in the same order than declared
 in the yaml.
@@ -81,9 +90,9 @@ in the yaml.
 The `request middlewares` are placed between the reader output and the writer input. In contrast `response middlewares` are placed between the writer output and the reader input.
 
 ```
-       |--->  Request middlewares --->|       
+       |--->  Request middlewares --->|
 Reader |                              | Writer
-       |<--- Response middlewares <---|       
+       |<--- Response middlewares <---|
 ```
 
 #### Usage examples

--- a/check.yaml
+++ b/check.yaml
@@ -1,0 +1,71 @@
+---
+# Source: homing-pigeon/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: release-name-homing-pigeon
+  labels:
+    app.kubernetes.io/name: homing-pigeon
+    helm.sh/chart: homing-pigeon-0.10.3
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+spec:
+  serviceName: homing-pigeon
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: homing-pigeon
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: homing-pigeon
+        app.kubernetes.io/instance: release-name
+    spec:
+      imagePullSecrets:
+      - name: myregistrykey
+      containers:
+      - name: homing-pigeon
+        image: "softonic/homing-pigeon:0.9.0"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: MESSAGE_BUFFER_LENGTH
+          value: "400"
+        - name: ACK_BUFFER_LENGTH
+          value: "200"
+        - name: REQUEST_MIDDLEWARES_SOCKET
+          value: "passthrough:///unix:///sockets/bF99VkdB1b"
+        volumeMounts:
+        - name: sockets
+          mountPath: "/sockets"
+  
+      - name: "middlewareName1"
+        image: "softonic/hp-pass-middleware:latest"
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        command:
+        - sh
+        - -c
+        - echo hello
+        args:
+        - world
+        env:
+        - name: ENV1
+          value: value1
+        - name: ENV2
+          value: value2
+        - name: IN_SOCKET
+          value: "passthrough:///unix:///sockets/bF99VkdB1b"
+        volumeMounts:
+        - name: sockets
+          mountPath: "/sockets"
+      volumes:
+      - name: sockets
+        emptyDir:
+          medium: "Memory"

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -35,6 +35,10 @@ spec:
 {{- tpl . $ | nindent 8 }}
 {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       {{- if or .Values.initContainers .Values.tplInitContainers }}
       initContainers:
       {{- end }}
@@ -145,8 +149,20 @@ spec:
       - name: "{{ $values.name }}"
         image: "{{ $values.repository }}:{{ $values.tag }}"
         imagePullPolicy: {{ $values.pullPolicy }}
-        env:
+        {{- with $values.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with $values.command }}
+        command:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $values.args }}
+        args:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with $values.env }}
+        env:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         - name: IN_SOCKET
@@ -177,8 +193,20 @@ spec:
       - name: "{{ $values.name }}"
         image: "{{ $values.repository }}:{{ $values.tag }}"
         imagePullPolicy: {{ $values.pullPolicy }}
-        env:
+        {{- with $values.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with $values.command }}
+        command:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $values.args }}
+        args:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with $values.env }}
+        env:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         - name: IN_SOCKET

--- a/test.yaml
+++ b/test.yaml
@@ -1,4 +1,6 @@
 # helm template --debug -f values.yaml -f test.yaml .
+imagePullSecrets:
+- name: myregistrykey
 requestMiddlewares:
 #### Middle
 #- name: middlewareName1
@@ -36,3 +38,27 @@ requestMiddlewares:
 #    pullPolicy: IfNotPresent
 #  - inSocket: "passthrough:///172.19.0.1:50051"
 #    outSocket: "passthrough:///172.19.0.1:50052"
+
+#### custom image args and env
+#  - name: middlewareName1
+#    repository: softonic/hp-pass-middleware
+#    tag: latest
+#    pullPolicy: IfNotPresent
+#    command:
+#    - "sh"
+#    - "-c"
+#    - "echo hello"
+#    args:
+#    - "world"
+#    env:
+#    - name: ENV1
+#      value: "value1"
+#    - name: ENV2
+#      value: "value2"
+#    resources:
+#      limits:
+#        cpu: 100m
+#        memory: 128Mi
+#      requests:
+#        cpu: 100m
+#        memory: 128Mi

--- a/values.yaml
+++ b/values.yaml
@@ -12,6 +12,8 @@ consumerId: null
 nameOverride: ""
 fullnameOverride: ""
 
+imagePullSecrets: []
+
 podLabels: {}
 podAnnotations: {}
 tplPodAnnotations: null
@@ -117,4 +119,3 @@ responseMiddlewares: []
 #    repository: softonic/hp-pass-middleware
 #    tag: latest
 #    pullPolicy: IfNotPresent
-


### PR DESCRIPTION
- Add support for middleware custom image `command`, `args`, `resources`.
- Add support for pod `imagePullSecrets` prop (in case your middleware or extra containers need to be pulled from a private registry)