### PR TITLE
fix: dont use schemes in_socket

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "0.3.0"
 description: Helm chart for Homing Pigeon
 name: homing-pigeon
 icon: https://raw.githubusercontent.com/softonic/homing-pigeon/master/images/logo.png
-version: 0.10.3
+version: 0.10.4
 maintainers:
 - name: Jose Manuel Cardona
   email: josemanuel.cardona@softonic.com

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Helm chart for https://github.com/softonic/homing-pigeon
 | `messageBufferLen`                        | Buffer length for write buffer                                                            | `400`                    |
 | `ackBufferLen`                            | Buffer length for acks                                                                    | `200`                    |
 | `caCerts`                                 | List of CA certs with `name` being an identifier, and `cert` the certificate in base64    | `null`                   |
+| `podSecurityContext`                      | Pod security context configuration                                                        | `{ fsGroup: 1000 }`      |
+| `securityContext`                         | Container security context                                                                | `{ runAsUser: 1000, runAsGroup: 1000 ... }` |
 | `reader.rabbitmq.enabled`                 | Enable RabbitMQ reader                                                                    | `false`                  |
 | `reader.rabbitmq.consumerName`            | Consumer identifier label                                                                 | `""`                     |
 | `reader.rabbitmq.url`                     | RabbitMQ url                                                                              | `""`                     |

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -35,6 +35,8 @@ spec:
 {{- tpl . $ | nindent 8 }}
 {{- end }}
     spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
       {{- toYaml . | nindent 6 }}
@@ -71,6 +73,8 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
         env:
         {{- with .Values.consumerId }}
         - name: CONSUMER_ID
@@ -149,6 +153,8 @@ spec:
       - name: "{{ $values.name }}"
         image: "{{ $values.repository }}:{{ $values.tag }}"
         imagePullPolicy: {{ $values.pullPolicy }}
+        securityContext:
+          {{- toYaml $.Values.securityContext | nindent 10 }}
         {{- with $values.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
@@ -193,6 +199,8 @@ spec:
       - name: "{{ $values.name }}"
         image: "{{ $values.repository }}:{{ $values.tag }}"
         imagePullPolicy: {{ $values.pullPolicy }}
+        securityContext:
+          {{- toYaml $.Values.securityContext | nindent 10 }}
         {{- with $values.resources }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -166,7 +166,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         - name: IN_SOCKET
-          value: "{{ $rqSocket }}"
+          value: "{{ $rqSocket | replace "passthrough:///unix://" "" }}"
     {{- if not ( eq ( add $index 1 ) ( len $.Values.requestMiddlewares ) ) }}
         {{- if hasKey (index $.Values.requestMiddlewares ( add $index 1 )) "inSocket" }}
           {{- $rqSocket = (index $.Values.requestMiddlewares ( add $index 1 )).inSocket }}
@@ -210,7 +210,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         - name: IN_SOCKET
-          value: "{{ $rpSocket }}"
+          value: "{{ $rpSocket | replace "passthrough:///unix://" "" }}"
     {{- if not ( eq ( add $index 1 ) ( len $.Values.responseMiddlewares ) ) }}
         {{- if hasKey (index $.Values.responseMiddlewares ( add $index 1 )) "inSocket" }}
           {{- $rpSocket = (index $.Values.responseMiddlewares ( add $index 1 )).inSocket }}

--- a/values.yaml
+++ b/values.yaml
@@ -21,7 +21,7 @@ tplPodAnnotations: null
 #   version: {{ .Release.Version }}
 image:
   repository: softonic/homing-pigeon
-  tag: 0.9.2
+  tag: 0.9.3
   pullPolicy: IfNotPresent
 
 passthrough:

--- a/values.yaml
+++ b/values.yaml
@@ -21,7 +21,7 @@ tplPodAnnotations: null
 #   version: {{ .Release.Version }}
 image:
   repository: softonic/homing-pigeon
-  tag: 0.9.0
+  tag: 0.9.2
   pullPolicy: IfNotPresent
 
 passthrough:
@@ -40,6 +40,20 @@ resources: {}
   # requests:
   #  cpu: 100m
   #  memory: 128Mi
+
+podSecurityContext:
+  fsGroup: 1000
+
+securityContext:
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
Middlewares based on "unimplemented" interface from homing-pigeon do not accept passthrough or unix schemes in the IN_SOCKET address.

These are intended only to be used by a grpc client, as the unix listener is created using the net library (`net.Listen('unix'...)`). See https://github.com/grpc/grpc/blob/master/doc/naming.md for more details.

Additionally, a default security context for pod and container has been introduced to avoid using root by default
